### PR TITLE
Add basic Benefits component

### DIFF
--- a/gatsby-theme-landing-page/package.json
+++ b/gatsby-theme-landing-page/package.json
@@ -15,6 +15,7 @@
     "gatsby-source-filesystem": "^4.3.0",
     "gatsby-transformer-remark": "^5.3.0",
     "gatsby-transformer-sharp": "^4.3.0",
+    "is-absolute-url": "^4.0.1",
     "react-helmet": "^6.1.0",
     "sanitize-html": "^2.6.0"
   },

--- a/gatsby-theme-landing-page/src/components/benefits.js
+++ b/gatsby-theme-landing-page/src/components/benefits.js
@@ -13,8 +13,8 @@ export default function Benefits({ heading, secondaryHeading, content }) {
           <h3 className={styles.subhead}>{secondaryHeading}</h3>
         )}
         <div className={styles.contentContainer}>
-          {content.map((c) => (
-            <Content key={c.id} {...c} />
+          {content.map((item) => (
+            <BenefitContent key={item.id} {...item} />
           ))}
         </div>
       </div>
@@ -22,7 +22,7 @@ export default function Benefits({ heading, secondaryHeading, content }) {
   );
 }
 
-function Content({ primaryText, secondaryText, image, links = [] }) {
+function BenefitContent({ primaryText, secondaryText, image, links = [] }) {
   return (
     <div className={styles.contentCard}>
       {image && (

--- a/gatsby-theme-landing-page/src/components/benefits.js
+++ b/gatsby-theme-landing-page/src/components/benefits.js
@@ -34,7 +34,6 @@ function Content({ primaryText, secondaryText, image, links = [] }) {
       )}
       <MarkdownText
         as="h3"
-        inline
         className={styles.contentHeading}
         {...primaryText}
       />

--- a/gatsby-theme-landing-page/src/components/benefits.js
+++ b/gatsby-theme-landing-page/src/components/benefits.js
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { GatsbyImage, getImage } from "gatsby-plugin-image";
+import * as styles from "./benefits.module.css";
+import MarkdownText from "./markdown-text";
+import Link from "./link";
+
+export default function Benefits({ heading, secondaryHeading, content }) {
+  return (
+    <section>
+      <div className={styles.container}>
+        <h2 className={styles.heading}>{heading}</h2>
+        {secondaryHeading && (
+          <h3 className={styles.subhead}>{secondaryHeading}</h3>
+        )}
+        <div className={styles.contentContainer}>
+          {content.map((c) => (
+            <Content key={c.id} {...c} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Content({ primaryText, secondaryText, image, links = [] }) {
+  return (
+    <div className={styles.contentCard}>
+      {image && (
+        <GatsbyImage
+          image={getImage(image)}
+          alt={"TODO get alt text"}
+          className={styles.contentImage}
+        />
+      )}
+      <MarkdownText
+        as="h3"
+        inline
+        className={styles.contentHeading}
+        {...primaryText}
+      />
+      <MarkdownText {...secondaryText} />
+      <div>
+        {links && links.map((link) => <Link key={link.id} {...link} />)}
+      </div>
+    </div>
+  );
+}

--- a/gatsby-theme-landing-page/src/components/benefits.module.css
+++ b/gatsby-theme-landing-page/src/components/benefits.module.css
@@ -1,0 +1,56 @@
+.root {
+}
+
+.container {
+  composes: container from "./base.module.css";
+  padding-top: var(--space-5);
+  padding-bottom: var(--space-5);
+}
+
+.heading {
+  font-size: var(--font-size-5);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.subhead {
+  font-size: var(--font-size-4);
+  margin-top: 0;
+  margin-bottom: var(--space-4);
+}
+
+.contentContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.contentCard {
+}
+
+.contentCard p {
+  margin-top: 0;
+  margin-bottom: var(--space-2);
+}
+
+.contentHeading {
+  font-size: var(--font-size-4);
+  margin-top: 0;
+  margin-bottom: var(--space-2);
+}
+
+.contentImage {
+  margin-bottom: var(--space-3);
+}
+
+@media screen and (min-width: 48em) {
+  .contentContainer {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .contentCard {
+    /* ensure cards are equal width */
+    /* 0px unit is included for IE */
+    flex: 1 1 0px;
+  }
+}

--- a/gatsby-theme-landing-page/src/components/button.js
+++ b/gatsby-theme-landing-page/src/components/button.js
@@ -1,10 +1,20 @@
 import * as React from "react";
 import { Link } from "gatsby";
+import isAbsoluteURL from "is-absolute-url";
 import * as styles from "./button.module.css";
 
 export default function Button({ href, text, children, variant = "primary" }) {
   const buttonStyle =
     variant === "primary" ? styles.buttonPrimary : styles.buttonSecondary;
+
+  if (isAbsoluteURL(href)) {
+    return (
+      <a className={buttonStyle} href={href}>
+        {text || children}
+      </a>
+    );
+  }
+
   return (
     <Link className={buttonStyle} to={href}>
       {text || children}

--- a/gatsby-theme-landing-page/src/components/call-to-action.js
+++ b/gatsby-theme-landing-page/src/components/call-to-action.js
@@ -3,14 +3,9 @@ import * as styles from "./call-to-action.module.css";
 import MarkdownText from "./markdown-text";
 import Button from "./button";
 
-export default function CallToAction({
-  heading,
-  secondaryHeading,
-  content,
-  ...props
-}) {
+export default function CallToAction({ heading, secondaryHeading, content }) {
   return (
-    <div className={styles.root}>
+    <section className={styles.root}>
       <div className={styles.container}>
         <h2>{heading}</h2>
         {secondaryHeading && <h3>{secondaryHeading}</h3>}
@@ -18,7 +13,7 @@ export default function CallToAction({
           <Content key={c.id} {...c} />
         ))}
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -28,9 +23,7 @@ function Content({ primaryText, secondaryText, links = [] }) {
       <MarkdownText {...primaryText} />
       <MarkdownText {...secondaryText} />
       <div className={styles.buttons}>
-        {links.map((link) => (
-          <Button key={link.id} {...link} />
-        ))}
+        {links && links.map((link) => <Button key={link.id} {...link} />)}
       </div>
     </div>
   );

--- a/gatsby-theme-landing-page/src/components/copy.module.css
+++ b/gatsby-theme-landing-page/src/components/copy.module.css
@@ -36,6 +36,9 @@
   font-size: var(--font-size-4);
 }
 
+.primaryText {
+}
+
 .asideText {
   font-style: italic;
   color: var(--text-color-secondary);

--- a/gatsby-theme-landing-page/src/components/index.js
+++ b/gatsby-theme-landing-page/src/components/index.js
@@ -1,3 +1,4 @@
 export { default as Hero } from "./hero";
 export { default as Features } from "./features";
 export { default as CallToAction } from "./call-to-action";
+export { default as Benefits } from "./benefits";

--- a/gatsby-theme-landing-page/src/components/link.js
+++ b/gatsby-theme-landing-page/src/components/link.js
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { Link } from "gatsby";
+import isAbsoluteURL from "is-absolute-url";
+import * as styles from "./link.module.css";
+
+export default function ({ href, text, children }) {
+  if (isAbsoluteURL(href)) {
+    return (
+      <a className={styles.link} href={href}>
+        {text || children}
+      </a>
+    );
+  }
+
+  return (
+    <Link className={styles.link} to={href}>
+      {text || children}
+    </Link>
+  );
+}

--- a/gatsby-theme-landing-page/src/components/link.js
+++ b/gatsby-theme-landing-page/src/components/link.js
@@ -1,9 +1,9 @@
 import * as React from "react";
-import { Link } from "gatsby";
+import { Link as GatsbyLink } from "gatsby";
 import isAbsoluteURL from "is-absolute-url";
 import * as styles from "./link.module.css";
 
-export default function ({ href, text, children }) {
+export default function Link({ href, text, children }) {
   if (isAbsoluteURL(href)) {
     return (
       <a className={styles.link} href={href}>
@@ -13,8 +13,8 @@ export default function ({ href, text, children }) {
   }
 
   return (
-    <Link className={styles.link} to={href}>
+    <GatsbyLink className={styles.link} to={href}>
       {text || children}
-    </Link>
+    </GatsbyLink>
   );
 }

--- a/gatsby-theme-landing-page/src/components/link.module.css
+++ b/gatsby-theme-landing-page/src/components/link.module.css
@@ -1,0 +1,8 @@
+.link {
+  color: var(--link-color);
+}
+
+.link:hover,
+.link:focus {
+  color: var(--link--hover-color);
+}

--- a/gatsby-theme-landing-page/src/components/markdown-text.js
+++ b/gatsby-theme-landing-page/src/components/markdown-text.js
@@ -29,16 +29,17 @@ const inlineOptions = {
 
 export default function MarkdownText({
   childMarkdownRemark,
-  as = "div",
+  as,
   className = "",
   inline = false,
   ...rest
 }) {
   if (!childMarkdownRemark) return null;
-  const sanitizeOptions = inline ? inlineOptions : blockOptions;
 
+  const shouldUseInline = !!as || inline;
+  const sanitizeOptions = shouldUseInline ? inlineOptions : blockOptions;
   const sanitized = sanitize(childMarkdownRemark.html, sanitizeOptions);
-  const Component = as;
+  const Component = as || "div";
 
   return (
     <Component

--- a/gatsby-theme-landing-page/src/components/markdown-text.js
+++ b/gatsby-theme-landing-page/src/components/markdown-text.js
@@ -31,12 +31,11 @@ export default function MarkdownText({
   childMarkdownRemark,
   as,
   className = "",
-  inline = false,
   ...rest
 }) {
   if (!childMarkdownRemark) return null;
 
-  const shouldUseInline = !!as || inline;
+  const shouldUseInline = !!as;
   const sanitizeOptions = shouldUseInline ? inlineOptions : blockOptions;
   const sanitized = sanitize(childMarkdownRemark.html, sanitizeOptions);
   const Component = as || "div";

--- a/gatsby-theme-landing-page/src/components/markdown-text.js
+++ b/gatsby-theme-landing-page/src/components/markdown-text.js
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as sanitize from "sanitize-html";
 import * as styles from "./markdown-text.module.css";
 
-const sanitizeOptions = {
+const blockOptions = {
   allowedTags: [
     "p",
     "a",
@@ -21,14 +21,26 @@ const sanitizeOptions = {
   selfClosing: ["img", "hr"],
 };
 
-export default function MarkdownText({ childMarkdownRemark }) {
+const inlineOptions = {
+  allowedTags: ["strong", "b", "i", "em", "a", "span"],
+  selfClosing: [],
+};
+
+export default function MarkdownText({
+  childMarkdownRemark,
+  as = "div",
+  className = "",
+  inline = false,
+}) {
   if (!childMarkdownRemark) return null;
+  const sanitizeOptions = inline ? inlineOptions : blockOptions;
 
   const sanitized = sanitize(childMarkdownRemark.html, sanitizeOptions);
+  const Component = as;
 
   return (
-    <div
-      className={styles.root}
+    <Component
+      className={[styles.root, className].join(" ")}
       dangerouslySetInnerHTML={{ __html: sanitized }}
     />
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6423,6 +6423,11 @@ is-absolute-url@^3.0.0, is-absolute-url@^3.0.3:
   resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-3.0.3.tgz#96c6a22b6a23929b11ea0afb1836c36ad4a5d698"
   integrity sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==
 
+is-absolute-url@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-4.0.1.tgz#16e4d487d4fded05cfe0685e53ec86804a5e94dc"
+  integrity sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==
+
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"


### PR DESCRIPTION
- Adds Benefit component where content is shown in a single row as "cards"
- Adds Link component – using this instead of Button for the links in content
- Checks for absolute URLs in Link and Button to avoid warnings from GatsbyLink
- Adds `inline` and `as` props to MarkdownText to allow the content to be rendered as a heading; definitely would like to know what you think about this approach
- Passes `className` to MarkdownText; I'll merge your changes before this one and address any potential conflicts

![image](https://user-images.githubusercontent.com/3451712/144506055-c537e218-4ae6-4fc6-a37b-0084b218431c.png)
