### PR TITLE
add alt tags to images

### DIFF
--- a/gatsby-theme-landing-page/src/components/markdown-text.js
+++ b/gatsby-theme-landing-page/src/components/markdown-text.js
@@ -2,6 +2,9 @@ import * as React from "react";
 import * as sanitize from "sanitize-html";
 import * as styles from "./markdown-text.module.css";
 
+export const getText = (markdownTextNode) =>
+  sanitize(markdownTextNode.childMarkdownRemark.html, { allowedTags: [] });
+
 const blockOptions = {
   allowedTags: [
     "p",

--- a/gatsby-theme-landing-page/src/pages/{ContentfulLandingPage.slug}.js
+++ b/gatsby-theme-landing-page/src/pages/{ContentfulLandingPage.slug}.js
@@ -51,9 +51,11 @@ export const query = graphql`
           }
           image {
             gatsbyImageData(layout: CONSTRAINED)
+            title
           }
           avatar: image {
             gatsbyImageData(layout: FIXED, width: 96, height: 96)
+            title
           }
           links {
             id

--- a/gatsby-theme-landing-page/src/sections/benefits.js
+++ b/gatsby-theme-landing-page/src/sections/benefits.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import * as styles from "./benefits.module.css";
-import MarkdownText from "../components/markdown-text";
+import MarkdownText, { getText } from "../components/markdown-text";
 import Link from "../components/link";
 import LinkContainer from "../components/link-container";
 import Section from "../components/section";
@@ -30,7 +30,7 @@ function BenefitContent({ primaryText, secondaryText, image, links = [] }) {
       {image && (
         <GatsbyImage
           image={getImage(image)}
-          alt={"TODO get alt text"}
+          alt={image.title || getText(primaryText)}
           className={styles.contentImage}
         />
       )}

--- a/gatsby-theme-landing-page/src/sections/copy.js
+++ b/gatsby-theme-landing-page/src/sections/copy.js
@@ -1,6 +1,6 @@
 import React from "react";
 import * as styles from "./copy.module.css";
-import MarkdownText from "../components/markdown-text";
+import MarkdownText, { getText } from "../components/markdown-text";
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import Section from "../components/section";
 import Heading from "../components/heading";
@@ -23,8 +23,11 @@ export default function Copy({ heading, secondaryHeading, content }) {
 function CopyContent({ primaryText, secondaryText, image }) {
   return (
     <div className={styles.copyContainer}>
-      <div className={styles.imageContainer}>
-        <GatsbyImage image={getImage(image)} />
+      <div>
+        <GatsbyImage
+          image={getImage(image)}
+          alt={image.title || getText(primaryText)}
+        />
       </div>
       <MarkdownText {...primaryText} />
       <AsideText {...secondaryText} />

--- a/gatsby-theme-landing-page/src/sections/features.js
+++ b/gatsby-theme-landing-page/src/sections/features.js
@@ -1,7 +1,7 @@
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import * as React from "react";
 import * as styles from "./features.module.css";
-import MarkdownText from "../components/markdown-text";
+import MarkdownText, { getText } from "../components/markdown-text";
 import Link from "../components/link";
 import LinkContainer from "../components/link-container";
 import Section from "../components/section";
@@ -45,7 +45,10 @@ function Feature({
       </div>
       <div className={styles.imageContainer}>
         <div className={styles.imageWrapper}>
-          <GatsbyImage image={getImage(image)} />
+          <GatsbyImage
+            image={getImage(image)}
+            alt={image.title || getText(primaryText)}
+          />
         </div>
       </div>
     </div>

--- a/gatsby-theme-landing-page/src/sections/hero.js
+++ b/gatsby-theme-landing-page/src/sections/hero.js
@@ -17,7 +17,7 @@ export default function Hero({ heading, secondaryHeading, content }) {
           <HeroContent {...heroContent} />
         </div>
         <div className={styles.image}>
-          <GatsbyImage image={image} />
+          <GatsbyImage image={image} alt={image.title || `Hero Image`} />
         </div>
       </div>
     </section>

--- a/gatsby-theme-landing-page/src/sections/testimonial.js
+++ b/gatsby-theme-landing-page/src/sections/testimonial.js
@@ -22,23 +22,25 @@ export default function Testimonial({ heading, secondaryHeading, content }) {
 }
 
 function TestimonialContent({ primaryText, secondaryText, avatar }) {
-  return primaryText ? (
+  if (!primaryText) return;
+
+  return (
     <div className={styles.testimonial}>
       <div className={styles.quote}>
         <MarkdownText {...primaryText} />
       </div>
       <Divider />
       <div className={styles.author}>
-        <div>
+        {avatar && (
           <div className={styles.avatar}>
             <GatsbyImage
               image={getImage(avatar)}
               alt={avatar.title || getText(primaryText)}
             />
           </div>
-        </div>
+        )}
         <MarkdownText className={styles.authorInfo} {...secondaryText} />
       </div>
     </div>
-  ) : null;
+  );
 }

--- a/gatsby-theme-landing-page/src/sections/testimonial.js
+++ b/gatsby-theme-landing-page/src/sections/testimonial.js
@@ -2,7 +2,7 @@ import React from "react";
 import * as styles from "./testimonial.module.css";
 import Section from "../components/section";
 import Heading from "../components/heading";
-import MarkdownText from "../components/markdown-text";
+import MarkdownText, { getText } from "../components/markdown-text";
 import ContentContainer from "../components/content-container";
 import Divider from "../components/divider";
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
@@ -31,7 +31,10 @@ function TestimonialContent({ primaryText, secondaryText, avatar }) {
       <div className={styles.author}>
         <div>
           <div className={styles.avatar}>
-            <GatsbyImage image={getImage(avatar)} />
+            <GatsbyImage
+              image={getImage(avatar)}
+              alt={avatar.title || getText(primaryText)}
+            />
           </div>
         </div>
         <MarkdownText className={styles.authorInfo} {...secondaryText} />


### PR DESCRIPTION
Adds alt tags to images. Because the backup alt text is sourced from primaryText, this also exports a new function `getText` from MarkdownText.js, which returns html-stripped text from the contentful text node.