### PR TITLE
Use downloadLocal option for images

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,8 +11,5 @@ module.exports = {
         environment: process.env.CONTENTFUL_ENVIRONMENT_ID || "master",
       },
     },
-    `gatsby-plugin-image`,
-    `gatsby-plugin-sharp`,
-    `gatsby-transformer-sharp`, // Needed for dynamic images
   ],
 };

--- a/gatsby-theme-landing-page/gatsby-config.js
+++ b/gatsby-theme-landing-page/gatsby-config.js
@@ -7,6 +7,7 @@ module.exports = (opts = {}) => {
       {
         resolve: "gatsby-source-contentful",
         options: {
+          downloadLocal: true,
           ...opts,
         },
       },


### PR DESCRIPTION
@wardpeet recommended using the `downloadLocal` option in `gatsby-source-contentful` for better image performance. This also removes plugins that were included twice in the gatsby-config