### PR TITLE
Add more links to official docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,13 @@ A quick look at the files and directories included in this project:
 └── .env.example
 ```
 
-1. **`gatsby-config.js`**: Gatsby config file for the starter, which includes `gatsby-theme-landing-page` as a plugin.
-1. **`gatsby-theme-landing-page`**: The theme that includes the Contentful source plugin and most of the functionality. See the theme's [`README.md`][theme readme] for more information.
+1. **`gatsby-config.js`**: [Gatsby config][] file for the starter, which includes `gatsby-theme-landing-page` as a plugin.
+1. **`gatsby-theme-landing-page`**: The [theme][theme docs] that includes the Contentful source plugin and most of the functionality. See the theme's [`README.md`][theme readme] for more information.
 1. **`src/`**: The source directory for the starter. This includes an example of using the [Shadowing API][] to customize landing pages provided by the theme.
 1. **`.env.example`**: Copy this file, rename it to `.env`, and add your Contentful API keys to connect this data to your Contentful space.
 
+[gatsby config]: https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/
+[theme docs]: https://www.gatsbyjs.com/docs/themes/
 [shadowing api]: https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/shadowing/
 
 ### Detailed look into the theme
@@ -103,7 +105,7 @@ A quick look at the files and directories included in this project:
 ```
 
 This starter uses `gatsby-theme-landing-page` to source content from Contentful and create block-based landing pages.
-This theme is included in this repo's Yarn Workspace for local development.
+The theme is included in this repo's Yarn Workspace for local development.
 
 1. **`src/sections`**: Each landing page in Contentful determines which components it uses and controls the order of these sections.
    The components rendered by the theme are in `src/sections`. Each component in this directory represents one Contentful `LandingPageSection` node.
@@ -248,6 +250,8 @@ query ($id: String!) {
 ```
 
 <!-- TODO add screenshot -->
+
+To read more about customizing, see the theme's [README.md][theme readme].
 
 ## 🎓 Learning Gatsby
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ A quick look at the files and directories included in this project:
 .
 ├── README.md
 ├── gatsby-config.js
+├── gatsby-node.js
 ├── gatsby-theme-landing-page
 │   ├── README.md
 │   ├── gatsby-config.js
@@ -83,11 +84,13 @@ A quick look at the files and directories included in this project:
 ```
 
 1. **`gatsby-config.js`**: [Gatsby config][] file for the starter, which includes `gatsby-theme-landing-page` as a plugin.
+1. **`gatsby-node.js`**: [Gatsby Node][] config file for the starter, which includes GraphQL type definitions for the Contentful content model.
 1. **`gatsby-theme-landing-page`**: The [theme][theme docs] that includes the Contentful source plugin and most of the functionality. See the theme's [`README.md`][theme readme] for more information.
 1. **`src/`**: The source directory for the starter. This includes an example of using the [Shadowing API][] to customize landing pages provided by the theme.
 1. **`.env.example`**: Copy this file, rename it to `.env`, and add your Contentful API keys to connect this data to your Contentful space.
 
 [gatsby config]: https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/
+[gatsby node]: https://www.gatsbyjs.com/docs/reference/config-files/gatsby-node/
 [theme docs]: https://www.gatsbyjs.com/docs/themes/
 [shadowing api]: https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/shadowing/
 
@@ -250,6 +253,11 @@ query ($id: String!) {
 ```
 
 <!-- TODO add screenshot -->
+
+### Schema Customization API
+
+To prevent errors from occuring when changes are made to the Contentful content model, this starter includes GraphQL type definitions in its [`gatsby-node.js`](gatsby-node.js) file.
+If you decide to make changes to your content model, be sure to update the type definitions in this file, otherwise the starter might not be able to query new or renamed fields.
 
 To read more about customizing, see the theme's [README.md][theme readme].
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ query ($id: String!) {
 }
 ```
 
-<!-- TODO add screenshot -->
 
 ### Schema Customization API
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,36 +1,36 @@
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions;
-  const typeDefs = `  
+  const typeDefs = `
     type ContentfulLandingPage implements ContentfulReference & ContentfulEntry & Node @dontInfer {
-        name: String
-        slug: String
-        noIndex: Boolean
-        title: String
-        description: String
-        image: ContentfulAsset @link(by: "id", from: "image___NODE")
-        sections: [ContentfulLandingPageSection] @link(by: "id", from: "sections___NODE")
+      name: String
+      slug: String
+      noIndex: Boolean
+      title: String
+      description: String
+      image: ContentfulAsset @link(by: "id", from: "image___NODE")
+      sections: [ContentfulLandingPageSection] @link(by: "id", from: "sections___NODE")
     }
 
     type ContentfulLandingPageSection implements ContentfulReference & ContentfulEntry & Node  @dontInfer {
-        name: String
-        component: String
-        heading: String
-        content: [ContentfulLandingPageContent] @link(by: "id", from: "content___NODE")
-        secondaryHeading: String
-        }
+      name: String
+      component: String
+      heading: String
+      content: [ContentfulLandingPageContent] @link(by: "id", from: "content___NODE")
+      secondaryHeading: String
+    }
 
-        type ContentfulLandingPageContent implements ContentfulReference & ContentfulEntry & Node @dontInfer {
-        name: String
-        image: ContentfulAsset @link(by: "id", from: "image___NODE")
-        links: [ContentfulLink] @link(by: "id", from: "links___NODE")
-        primaryText: contentfulLandingPageContentPrimaryTextTextNode @link(by: "id", from: "primaryText___NODE")
-        secondaryText: contentfulLandingPageContentSecondaryTextTextNode @link(by: "id", from: "secondaryText___NODE")
-        }
-        
-        type ContentfulLink implements ContentfulReference & ContentfulEntry & Node @dontInfer {
-        href: String
-        text: String
-        }
+    type ContentfulLandingPageContent implements ContentfulReference & ContentfulEntry & Node @dontInfer {
+      name: String
+      image: ContentfulAsset @link(by: "id", from: "image___NODE")
+      links: [ContentfulLink] @link(by: "id", from: "links___NODE")
+      primaryText: contentfulLandingPageContentPrimaryTextTextNode @link(by: "id", from: "primaryText___NODE")
+      secondaryText: contentfulLandingPageContentSecondaryTextTextNode @link(by: "id", from: "secondaryText___NODE")
+    }
+
+    type ContentfulLink implements ContentfulReference & ContentfulEntry & Node @dontInfer {
+      href: String
+      text: String
+    }
   `;
 
   createTypes(typeDefs);

--- a/gatsby-theme-landing-page/README.md
+++ b/gatsby-theme-landing-page/README.md
@@ -133,6 +133,30 @@ The `Head` component is a wrapper around [React Helmet][] to add page-level meta
 - `image`: sets the Open Graph image
 - `noIndex` (boolean): set this as `true` to prevent search engine indexing
 
+#### `Link` Component
+
+```jsx
+// example usage
+import { Link } from "gatsby-theme-landing-page";
+
+<Link href="/">Home</Link>;
+```
+
+The `Link` component is a wrapper around [Gatsby Link][] with minimal styling.
+
+[gatsby link]: https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-link/
+
+**Props:**
+
+- `href`: URL for the link, which can handle absolute or relative links
+- `children` or `text`: text or React node to render as a link
+
+#### `Button` Component
+
+#### `Container` Component
+
+#### `Heading` Component
+
 ## Customization
 
 ### Typography, colors, and layout

--- a/gatsby-theme-landing-page/README.md
+++ b/gatsby-theme-landing-page/README.md
@@ -153,9 +153,54 @@ The `Link` component is a wrapper around [Gatsby Link][] with minimal styling.
 
 #### `Button` Component
 
+```jsx
+// example usage
+import { Button } from "gatsby-theme-landing-page";
+
+<Button href="/sign-up">Get Started</Button>;
+```
+
+The `Button` component is similar to the `Link` component, but styled to look like a call-to-action button.
+
+**Props:**
+
+- `href`: URL for the link, which can handle absolute or relative links
+- `children` or `text`: text or React node to render as a link
+- `variant`: string for button style variant, either `primary` or `secondary`
+
 #### `Container` Component
 
+```jsx
+// example usage
+import { Container } from "gatsby-theme-landing-page";
+
+<Container>Centered content</Container>;
+```
+
+The `Container` component is used to set a max-width and center content on the page. It's used internally by the `Section` component that wraps all _Section_ components.
+
+**Props:**
+
+- `className`: pass an additional HTML class attribute, which can be used for styling
+- All other props are passed directly to the root element.
+
 #### `Heading` Component
+
+```jsx
+import { Heading } from "gatsby-theme-landing-page";
+
+<Heading>Hello</Heading>;
+```
+
+The `Heading` component is used to render styled heading elements.
+
+**Props:**
+
+- `as`: renders this component as a different HTML element
+- `secondary` (boolean): renders the heading with styles for subheadings
+- `center` (boolean): sets text-align center
+- `className`: pass an additional HTML class attribute, which can be used for styling
+- All other props are passed directly to the root element.
 
 ## Customization
 

--- a/gatsby-theme-landing-page/README.md
+++ b/gatsby-theme-landing-page/README.md
@@ -80,7 +80,9 @@ To customize the built-in components' typography, colors, and layout, shadow the
 src/gatsby-theme-landing-page/styles/variables.module.css
 ```
 
-The components use CSS Modules with CSS custom properties that can be customized.
+The components use [CSS Modules][] with CSS custom properties that can be customized.
+
+[css modules]: https://www.gatsbyjs.com/docs/how-to/styling/css-modules/
 
 ```css
 /* example src/gatsby-theme-landing-page/styles/variables.module.css */
@@ -233,6 +235,8 @@ query ($id: String!) {
   }
 }
 ```
+
+You can read more about querying data in the [Gatsby docs](https://www.gatsbyjs.com/docs/how-to/querying-data/page-query/).
 
 ## Customizing buttons, links, and other components
 

--- a/gatsby-theme-landing-page/README.md
+++ b/gatsby-theme-landing-page/README.md
@@ -74,6 +74,65 @@ Each section contains up to two headings, and at least one **Content** block*.*
 
 **Content**: which represents the content in a given section. Content blocks contain _primary text, secondary text, an image, and up to two links._ How these content fields are rendered depends on the type of Section (e.g. which component) they belong to.
 
+## Components
+
+### Section Components
+
+There are 6 built-in section components available:
+
+- **Hero**: A two-column component with headings, an image, and CTA links. Intended to state the purpose of the landing page.
+- **Copy**: Long form text with blockquotes and full-column images, best for articles and instructions.
+- **CallToAction**: Centered text with CTA links
+- **Features**: large section with image and text side-by-side, often used to list features of a product offering
+- **Benefits**: Tiled cards, often used to list the benefits of a given offering.
+- **Testimonial** Centered text with separate sections for quote and author, often used for social proof.
+
+Content authors can choose any one of these components to render a content _Section_ when creating and editing landing pages.
+
+### Shared Components
+
+These section components use several shared components internally for a consistent look and feel. These components are also exported for use when creating custom section components, custom layouts, or for general use.
+
+#### `MarkdownText` Component
+
+```jsx
+// example usage
+import { MarkdownText } from "gatsby-theme-landing-page";
+
+<MarkdownText {...primaryText} />;
+```
+
+Use the `MarkdownText` component to sanitize and render rich text fields from Contentful.
+
+**Props:**
+
+- `childMarkdownRemark`: HTML returned from `gatsby-source-contentful`
+- `as`: renders this component as a different HTML element and removes block level elements from HTML
+- `className`: pass an additional HTML class attribute, which can be used for styling
+- All other props are passed directly to the root element
+
+#### `Head` Component
+
+```jsx
+// example usage
+import { Head } from "gatsby-theme-landing-page";
+
+<Head>
+  <title>Example</title>
+</Head>;
+```
+
+The `Head` component is a wrapper around [React Helmet][] to add page-level metadata to your pages in your site.
+
+[react helmet]: https://www.gatsbyjs.com/docs/add-page-metadata/
+
+**Props:**
+
+- `title`: sets the page title, as well as Open Graph metadata
+- `description`: sets the page description, as well as Open Graph metadata
+- `image`: sets the Open Graph image
+- `noIndex` (boolean): set this as `true` to prevent search engine indexing
+
 ## Customization
 
 ### Typography, colors, and layout

--- a/gatsby-theme-landing-page/index.js
+++ b/gatsby-theme-landing-page/index.js
@@ -1,4 +1,7 @@
 // public component API
 export { default as MarkdownText } from "./src/components/markdown-text";
-export { default as Link } from "./src/components/link";
 export { default as Head } from "./src/components/head";
+export { default as Link } from "./src/components/link";
+export { default as Button } from "./src/components/button";
+export { default as Container } from "./src/components/container";
+export { default as Heading } from "./src/components/heading";

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/gatsbyjs/gatsby-starter-landing-page#readme",
   "dependencies": {
     "gatsby": "^4.2.0",
-    "gatsby-theme-landing-page": "*",
+    "gatsby-theme-landing-page": "1.0.0-0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },


### PR DESCRIPTION
Adds more documentation for:

- The schema customization API in the `gatsby-node.js` config
- Adds links to official Gatsby docs for certain concepts
- Adds documentation for the theme's exported components
- Exports `Link`, `Button`, `Heading`, and `Container` components