### PR TITLE
Bump `gatsby-provision-contentful` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "chalk": "^4.0.0",
-    "contentful-import": "^8.2.28",
+    "contentful-import": "^8.5.21",
     "gatsby-provision-contentful": "^0.0.5",
     "husky": ">=6",
     "inquirer": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "gatsby-starter-landing-page",
   "private": true,
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "workspaces": [
     ".",
     "gatsby-theme-landing-page"
@@ -40,7 +43,7 @@
   "devDependencies": {
     "chalk": "^4.0.0",
     "contentful-import": "^8.2.28",
-    "gatsby-provision-contentful": "^0.0.3",
+    "gatsby-provision-contentful": "^0.0.5",
     "husky": ">=6",
     "inquirer": "^8.2.0",
     "lint-staged": ">=10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3728,24 +3728,6 @@ contentful-batch-libs@^9.4.2:
     lodash.clonedeep "^4.5.0"
     uuid "^8.3.2"
 
-contentful-import@^8.2.28:
-  version "8.5.4"
-  resolved "https://registry.yarnpkg.com/contentful-import/-/contentful-import-8.5.4.tgz#a52c2fd1b02eae7096142bd81b05eabeb7282932"
-  integrity sha512-5oJhbggAxcd4KPc9xkrhtgqGTyQAwWZnO/+t2mNvzDAp2GQjQ+2BtRFxf1FlWwbFq6R6xCi9v/T6pNHl33B9tg==
-  dependencies:
-    bluebird "^3.5.1"
-    cli-table3 "^0.6.0"
-    contentful-batch-libs "^9.4.2"
-    contentful-management "^10.19.1"
-    date-fns "^2.29.3"
-    joi "^17.7.0"
-    listr "^0.14.1"
-    listr-update-renderer "^0.5.0"
-    listr-verbose-renderer "^0.6.0"
-    lodash "^4.17.10"
-    p-queue "^6.6.2"
-    yargs "^17.6.2"
-
 contentful-import@^8.5.21:
   version "8.5.21"
   resolved "https://registry.yarnpkg.com/contentful-import/-/contentful-import-8.5.21.tgz#364b77ffe6f94c2fc903c97c91b6eab0b8912d84"
@@ -3763,17 +3745,6 @@ contentful-import@^8.5.21:
     lodash "^4.17.10"
     p-queue "^6.6.2"
     yargs "^17.6.2"
-
-contentful-management@^10.19.1:
-  version "10.19.1"
-  resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-10.19.1.tgz#efedaf3eabfb077149252f5e92aff4c6c9119db3"
-  integrity sha512-NrHyqhAG9IT2oPH91KhNbMwZSflQWyhF410C7LSMhTT0jx3/1yWI2u0XerN/Or1sDwmTioFJAm8JSecFoslSgw==
-  dependencies:
-    "@types/json-patch" "0.0.30"
-    axios "^0.27.1"
-    contentful-sdk-core "^7.0.1"
-    fast-copy "^2.1.1"
-    lodash.isplainobject "^4.0.6"
 
 contentful-management@^10.26.0:
   version "10.26.0"
@@ -5015,7 +4986,7 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
-fast-copy@^2.1.1, fast-copy@^2.1.7:
+fast-copy@^2.1.7:
   version "2.1.7"
   resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-2.1.7.tgz#affc9475cb4b555fb488572b2a44231d0c9fa39e"
   integrity sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3728,7 +3728,7 @@ contentful-batch-libs@^9.4.2:
     lodash.clonedeep "^4.5.0"
     uuid "^8.3.2"
 
-contentful-import@^8.2.28, contentful-import@^8.2.29:
+contentful-import@^8.2.28:
   version "8.5.4"
   resolved "https://registry.yarnpkg.com/contentful-import/-/contentful-import-8.5.4.tgz#a52c2fd1b02eae7096142bd81b05eabeb7282932"
   integrity sha512-5oJhbggAxcd4KPc9xkrhtgqGTyQAwWZnO/+t2mNvzDAp2GQjQ+2BtRFxf1FlWwbFq6R6xCi9v/T6pNHl33B9tg==
@@ -3737,6 +3737,24 @@ contentful-import@^8.2.28, contentful-import@^8.2.29:
     cli-table3 "^0.6.0"
     contentful-batch-libs "^9.4.2"
     contentful-management "^10.19.1"
+    date-fns "^2.29.3"
+    joi "^17.7.0"
+    listr "^0.14.1"
+    listr-update-renderer "^0.5.0"
+    listr-verbose-renderer "^0.6.0"
+    lodash "^4.17.10"
+    p-queue "^6.6.2"
+    yargs "^17.6.2"
+
+contentful-import@^8.5.21:
+  version "8.5.21"
+  resolved "https://registry.yarnpkg.com/contentful-import/-/contentful-import-8.5.21.tgz#364b77ffe6f94c2fc903c97c91b6eab0b8912d84"
+  integrity sha512-PGyahnV90WC0Kgo07evhvdHdXIz8npENgi372HmN4O0xxWsx4aa4iyn/2LeANLHKUG7oMPitCAMZiJXKzYDa5g==
+  dependencies:
+    bluebird "^3.5.1"
+    cli-table3 "^0.6.0"
+    contentful-batch-libs "^9.4.2"
+    contentful-management "^10.26.0"
     date-fns "^2.29.3"
     joi "^17.7.0"
     listr "^0.14.1"
@@ -3755,6 +3773,17 @@ contentful-management@^10.19.1:
     axios "^0.27.1"
     contentful-sdk-core "^7.0.1"
     fast-copy "^2.1.1"
+    lodash.isplainobject "^4.0.6"
+
+contentful-management@^10.26.0:
+  version "10.26.0"
+  resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-10.26.0.tgz#55fc33ddc730b32e449660ecf3a1e37ee4d0c037"
+  integrity sha512-7POoSUwqv1vto4Ud0y878lMiuJYH/mfulLzN/EMAyEv92QesGPatVR9jhBDvCTpPSXEa86oVRA+phw+hz7Ih1w==
+  dependencies:
+    "@types/json-patch" "0.0.30"
+    axios "^0.27.1"
+    contentful-sdk-core "^7.0.1"
+    fast-copy "^3.0.0"
     lodash.isplainobject "^4.0.6"
 
 contentful-resolve-response@^1.3.12:
@@ -4991,6 +5020,11 @@ fast-copy@^2.1.1, fast-copy@^2.1.7:
   resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-2.1.7.tgz#affc9475cb4b555fb488572b2a44231d0c9fa39e"
   integrity sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA==
 
+fast-copy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.0.tgz#875ebf33b13948ae012b6e51d33da5e6e7571ab8"
+  integrity sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -5555,13 +5589,13 @@ gatsby-plugin-utils@^4.0.0:
     mini-svg-data-uri "^1.4.4"
     svgo "^2.8.0"
 
-gatsby-provision-contentful@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/gatsby-provision-contentful/-/gatsby-provision-contentful-0.0.3.tgz#7e60c195582ddfaca5b29dabf56b4f16588fa98d"
-  integrity sha512-D63ebkdKV+MNi12FsLdArVRhXUO5LxY9WUIJRYED6P27tZvHGZLwFoZL5ku8Gyd2gt+nK/QdN9/kgQVOytxy7Q==
+gatsby-provision-contentful@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/gatsby-provision-contentful/-/gatsby-provision-contentful-0.0.5.tgz#d1c4e32dbf7c445659492527e1ff48b5918f4ef4"
+  integrity sha512-cWik9i1cqk0lWzTpjraiAGZ8pmA3efhduohByP+29zf9qAXF35LSVAd4Khpwx/e5GKD3TEIa7pVRnRDY/8G/9g==
   dependencies:
     chalk "4.1.0"
-    contentful-import "^8.2.29"
+    contentful-import "^8.5.21"
     inquirer "^8.2.2"
     yargs-parser "^21.0.1"
 


### PR DESCRIPTION
## Purpose

This bumps the version of `gatsby-provision-contentful` to resolve an issue raised originally here: https://github.com/gatsbyjs/gatsby-starter-landing-page/issues/45

I have confirmed that this corrects the pathing issue for where `.env` files get written locally:
<img width="699" alt="Screen Shot 2023-01-12 at 12 31 15 PM" src="https://user-images.githubusercontent.com/1790506/212137952-353abed5-d13e-4585-b16d-d1c7b705cbaf.png">
